### PR TITLE
Do not allow PayPal payment voiding

### DIFF
--- a/app/models/spree/alternative_payment_source.rb
+++ b/app/models/spree/alternative_payment_source.rb
@@ -22,7 +22,7 @@ module Spree
 
     # Indicates whether its possible to void the payment.
     def can_void?(payment)
-      !payment.void?
+      false
     end
 
     # Indicates whether its possible to capture the payment

--- a/app/models/spree/gateway/adyen_payment_encrypted.rb
+++ b/app/models/spree/gateway/adyen_payment_encrypted.rb
@@ -16,21 +16,17 @@ module Spree
       false
     end
 
-    def can_void?(payment)
-      payment.cvv_response_code == 'Authorised' && payment.pending?
-    end
-
     def authorize(amount, source, gateway_options = {})
 
       card = { encrypted: { json: source.encrypted_data } }
 
       # TODO: Make me conditional. Recurring must be true if payment profiles supported
       response = authorize_on_card amount, source, gateway_options, card, { recurring: true }
-
-      # TODO: MOve this to additional_params method to Adyen::API::AuthorisationResponse and merge in params method.
+      
+      # TODO: MOve this to additional_params method to Adyen::API::AuthorisationResponse and merge in params method. 
       # NOTE: Iterate through entry elements nested in the additionalData element of the response (see SOAP Envelope)
       last_digits = response.xml_querier.xpath('//payment:authoriseResponse/payment:paymentResult').text('./payment:additionalData/payment:entry/payment:value')
-
+      
       # Ensure that this is enabled if using Encrypted Gateway and Payment Profiles supported
       if last_digits.blank? && payment_profiles_supported?
         Exception.new('Please request last digits to be sent back in Adyen response to support payment profiles')


### PR DESCRIPTION
https://trello.com/c/fyrHsdeT/4-paypal-not-refunding-for-oos

Following a discussion with Paulo and Julien, we've decided to remove the ability to void payments when not applicable. For credit card payments this means when the payment is not pending, and never for Paypal payments.

This change only affects PayPal payments, as payment source for credit cards is Spree::CreditCard, not AdyenPaymentEncrypted. See this PR for related CC change: https://github.com/surfdome/surfdome/pull/4303