### PR TITLE
Fix penny rounding issue when paying with Adyen HPP

### DIFF
--- a/lib/spree/adyen/checkout_rescue.rb
+++ b/lib/spree/adyen/checkout_rescue.rb
@@ -29,7 +29,7 @@ module Spree
             merchant_account:   exception.source.payment_method.merchant_account,
             skin_code:          exception.source.payment_method.skin_code,
             shared_secret:      exception.source.payment_method.shared_secret,
-            payment_amount:     (payment.amount.to_f * 100).to_int,
+            payment_amount:     (payment.amount.to_f * 100).round,
             brandCode:          exception.source.brand_code
           }
 


### PR DESCRIPTION
Since ruby floats aren't precise enough, when multiplying a payment amount like 79.99 by 100, it would sometimes be 7998.999...

When converted to an integer, this became 7998. Using #round instead results in the correct value - 7999.