### PR TITLE
Fix error response for modifications (capture/void/credit)

### DIFF
--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -49,7 +49,7 @@ module Spree
         else
           # TODO confirm the error response will always have these two methods
           def response.to_s
-            "#{result_code} - #{refusal_reason}"
+            response
           end
         end
 
@@ -65,9 +65,8 @@ module Spree
         if response.success?
           def response.authorization; nil; end
         else
-          # TODO confirm the error response will always have these two methods
           def response.to_s
-            "#{result_code} - #{refusal_reason}"
+            response
           end
         end
         response
@@ -81,7 +80,7 @@ module Spree
           def response.authorization; nil; end
         else
           def response.to_s
-            refusal_reason
+            response
           end
         end
 


### PR DESCRIPTION
Return response from Response#to_s in case of error on Modification request.

https://trello.com/c/Mw4KaNDo/20-shipment-error-undefined-local-variable-or-method-result-code-for-adyen-api-paymentservice-captureresponse-0x000000122015e0